### PR TITLE
Feat/plugged in startup notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Options:
   -n, --notify-now                 Send desktop notification with current battery-level then exit
   -t, --list-thresholds            List all notification thresholds in the format 'a_1%, a_2%, ..., a_n%' that are specified in the config-file
   -p, --show-config-path           Display the path to the config-file
+      --emit-default-config        Print the default configuration as JSON then exit
   -b, --battery <BATTERY>          Pass the battery such as 'BAT1' if your system has multiple and you do not want to use the default (BAT0). Check '/sys/class/power_supply/' to see which batteries you have
   -h, --help                       Print help
   -V, --version                    Print version
@@ -95,6 +96,7 @@ This means that if you have an environment variable named `XDG_CONFIG_HOME` spec
 `XDG_CONFIG_HOME/powernotd/config.json`. If this environment variable is not present the configuration file will be created in the path:
 `~/.config/powernotd/config.json`.
 If you want to run powernotd with a custom configuration file use the `-f` or `--config-file` flag and provide your own path.
+Run `powernotd --emit-default-config` to print the default configuration to stdout.
 
 The configuration file is Json and the following is the annotated default configuration.
 Each entry in the `notifications` array contains a threshold for which a notification should be sent if the current power level drops
@@ -136,6 +138,26 @@ full_notification
   
 ```
 
+#### Plugged-in startup notifications
+
+The `plugged_in_startup_notification` configuration is a small UX improvement for daemon startup while the machine is already
+plugged in. By default, powernotd does not show threshold notifications in that state because no action is needed when the
+machine is already charging. It still shows the full battery notification by default, because you might want to unplug the
+machine once the battery is full.
+
+Both startup behaviors can be configured:
+
+```json
+"plugged_in_startup_notification": {
+  "show_full": true,
+  "show_threshold": false
+}
+```
+
+`show_full` controls whether the full battery notification is shown when powernotd starts while already plugged in and full.
+`show_threshold` controls whether threshold notifications are shown when powernotd starts while already plugged in and below a
+configured threshold. This only affects startup; threshold and full notifications still fire normally while powernotd is running.
+
 #### Charging hooks (plug/unplug events)
 
 Powernotd can run user-defined hooks when the AC adapter is plugged in or unplugged. Two optional top-level config sections,
@@ -156,6 +178,12 @@ charging_start (optional)
 charging_stop (optional)
 
     Same fields as charging_start; fires when the AC adapter is unplugged.
+    show_threshold_warning: boolean, if true powernotd emits the matching threshold warning when unplugged while already
+                            below a configured threshold. This is enabled by default in the default config so a startup
+                            threshold warning can be suppressed while plugged in, but still shown if you later unplug before
+                            the battery has charged above the threshold. This setting is independent from enabled.
+                            Note: this field is ignored if set on charging_start — by the time plug-in fires, any matching
+                            threshold notification has already been handled during the preceding discharge.
 ```
 
 `charging_start` fires on `Discharging → Charging` or `Discharging → Full` (i.e. plug-in, even if the battery is already at 100%).
@@ -232,6 +260,10 @@ Full default configuration file:
     "title": "Battery Status",
     "message": "Fully Charged 100%"
   },
+  "plugged_in_startup_notification": {
+    "show_full": true,
+    "show_threshold": false
+  },
   "charging_start": {
     "urgency": "Low",
     "enabled": false,
@@ -241,6 +273,7 @@ Full default configuration file:
   "charging_stop": {
     "urgency": "Low",
     "enabled": false,
+    "show_threshold_warning": true,
     "title": "Discharging",
     "message": "Unplugged at {}%"
   },

--- a/pkg/assets/completions/_powernotd
+++ b/pkg/assets/completions/_powernotd
@@ -29,6 +29,7 @@ _powernotd() {
 '--list-thresholds[List all notification thresholds in the format '\''a_1%, a_2%, ..., a_n%'\'' that are specified in the config-file]' \
 '-p[Display the path to the config-file]' \
 '--show-config-path[Display the path to the config-file]' \
+'--emit-default-config[Print the default configuration as JSON then exit]' \
 '--mute-notification-warning[Suppress the stderr warning printed when no desktop notification daemon (dunst, mako, notification-daemon, xfce4-notifyd, ...) is reachable on D-Bus. Notifications still attempt to fire; this only silences the diagnostic]' \
 '-h[Print help]' \
 '--help[Print help]' \

--- a/pkg/assets/completions/_powernotd.ps1
+++ b/pkg/assets/completions/_powernotd.ps1
@@ -35,6 +35,7 @@ Register-ArgumentCompleter -Native -CommandName 'powernotd' -ScriptBlock {
             [CompletionResult]::new('--list-thresholds', '--list-thresholds', [CompletionResultType]::ParameterName, 'List all notification thresholds in the format ''a_1%, a_2%, ..., a_n%'' that are specified in the config-file')
             [CompletionResult]::new('-p', '-p', [CompletionResultType]::ParameterName, 'Display the path to the config-file')
             [CompletionResult]::new('--show-config-path', '--show-config-path', [CompletionResultType]::ParameterName, 'Display the path to the config-file')
+            [CompletionResult]::new('--emit-default-config', '--emit-default-config', [CompletionResultType]::ParameterName, 'Print the default configuration as JSON then exit')
             [CompletionResult]::new('--mute-notification-warning', '--mute-notification-warning', [CompletionResultType]::ParameterName, 'Suppress the stderr warning printed when no desktop notification daemon (dunst, mako, notification-daemon, xfce4-notifyd, ...) is reachable on D-Bus. Notifications still attempt to fire; this only silences the diagnostic')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')

--- a/pkg/assets/completions/powernotd.bash
+++ b/pkg/assets/completions/powernotd.bash
@@ -23,7 +23,7 @@ _powernotd() {
 
     case "${cmd}" in
         powernotd)
-            opts="-s -c -f -n -t -p -b -h -V --status-level --charging-state --config-file --notify-now --list-thresholds --show-config-path --battery --mute-notification-warning --help --version"
+            opts="-s -c -f -n -t -p -b -h -V --status-level --charging-state --config-file --notify-now --list-thresholds --show-config-path --emit-default-config --battery --mute-notification-warning --help --version"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/pkg/assets/completions/powernotd.elv
+++ b/pkg/assets/completions/powernotd.elv
@@ -32,6 +32,7 @@ set edit:completion:arg-completer[powernotd] = {|@words|
             cand --list-thresholds 'List all notification thresholds in the format ''a_1%, a_2%, ..., a_n%'' that are specified in the config-file'
             cand -p 'Display the path to the config-file'
             cand --show-config-path 'Display the path to the config-file'
+            cand --emit-default-config 'Print the default configuration as JSON then exit'
             cand --mute-notification-warning 'Suppress the stderr warning printed when no desktop notification daemon (dunst, mako, notification-daemon, xfce4-notifyd, ...) is reachable on D-Bus. Notifications still attempt to fire; this only silences the diagnostic'
             cand -h 'Print help'
             cand --help 'Print help'

--- a/pkg/assets/completions/powernotd.fish
+++ b/pkg/assets/completions/powernotd.fish
@@ -5,6 +5,7 @@ complete -c powernotd -s c -l charging-state -d 'Print charging status \'chargin
 complete -c powernotd -s n -l notify-now -d 'Send desktop notification with current battery-level then exit'
 complete -c powernotd -s t -l list-thresholds -d 'List all notification thresholds in the format \'a_1%, a_2%, ..., a_n%\' that are specified in the config-file'
 complete -c powernotd -s p -l show-config-path -d 'Display the path to the config-file'
+complete -c powernotd -l emit-default-config -d 'Print the default configuration as JSON then exit'
 complete -c powernotd -l mute-notification-warning -d 'Suppress the stderr warning printed when no desktop notification daemon (dunst, mako, notification-daemon, xfce4-notifyd, ...) is reachable on D-Bus. Notifications still attempt to fire; this only silences the diagnostic'
 complete -c powernotd -s h -l help -d 'Print help'
 complete -c powernotd -s V -l version -d 'Print version'

--- a/pkg/assets/man/powernotd.1
+++ b/pkg/assets/man/powernotd.1
@@ -4,7 +4,7 @@
 .SH NAME
 powernotd \- Powernotd is a battery\-level notification daemon that sends notification using the xdg desktop notification standard.
 .SH SYNOPSIS
-\fBpowernotd\fR [\fB\-s\fR|\fB\-\-status\-level\fR] [\fB\-c\fR|\fB\-\-charging\-state\fR] [\fB\-f\fR|\fB\-\-config\-file\fR] [\fB\-n\fR|\fB\-\-notify\-now\fR] [\fB\-t\fR|\fB\-\-list\-thresholds\fR] [\fB\-p\fR|\fB\-\-show\-config\-path\fR] [\fB\-b\fR|\fB\-\-battery\fR] [\fB\-\-mute\-notification\-warning\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] 
+\fBpowernotd\fR [\fB\-s\fR|\fB\-\-status\-level\fR] [\fB\-c\fR|\fB\-\-charging\-state\fR] [\fB\-f\fR|\fB\-\-config\-file\fR] [\fB\-n\fR|\fB\-\-notify\-now\fR] [\fB\-t\fR|\fB\-\-list\-thresholds\fR] [\fB\-p\fR|\fB\-\-show\-config\-path\fR] [\fB\-\-emit\-default\-config\fR] [\fB\-b\fR|\fB\-\-battery\fR] [\fB\-\-mute\-notification\-warning\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] 
 .SH DESCRIPTION
 Powernotd is a battery\-level notification daemon that sends notification using the xdg desktop notification standard.
 .SH OPTIONS
@@ -26,6 +26,9 @@ List all notification thresholds in the format \*(Aqa_1%, a_2%, ..., a_n%\*(Aq t
 .TP
 \fB\-p\fR, \fB\-\-show\-config\-path\fR
 Display the path to the config\-file
+.TP
+\fB\-\-emit\-default\-config\fR
+Print the default configuration as JSON then exit
 .TP
 \fB\-b\fR, \fB\-\-battery\fR \fI<BATTERY>\fR
 Pass the battery such as \*(AqBAT1\*(Aq if your system has multiple and you do not want to use the default (BAT0). Check \*(Aq/sys/class/power_supply/\*(Aq to see which batteries you have

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,6 +30,10 @@ pub struct Args {
     #[arg(short = 'p', long, default_value_t = false)]
     pub show_config_path: bool,
 
+    /// Print the default configuration as JSON then exit
+    #[arg(long, default_value_t = false)]
+    pub emit_default_config: bool,
+
     /// Pass the battery such as 'BAT1' if your system has multiple and you do not want to use the
     /// default (BAT0). Check '/sys/class/power_supply/' to see which batteries you have.
     #[arg(short = 'b', long)]
@@ -66,6 +70,7 @@ mod tests {
         assert!(!a.notify_now);
         assert!(!a.list_thresholds);
         assert!(!a.show_config_path);
+        assert!(!a.emit_default_config);
         assert!(a.config_file.is_none());
         assert!(a.battery.is_none());
     }
@@ -104,6 +109,12 @@ mod tests {
     fn cli_parse_show_config_path_short() {
         let a = Args::try_parse_from(["powernotd", "-p"]).expect("parse");
         assert!(a.show_config_path);
+    }
+
+    #[test]
+    fn cli_parse_emit_default_config_long() {
+        let a = Args::try_parse_from(["powernotd", "--emit-default-config"]).expect("parse");
+        assert!(a.emit_default_config);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,28 +17,18 @@ fn default_poll_interval_secs() -> u32 {
     DEFAULT_POLL_INTERVAL_SECS
 }
 
-fn default_plugged_in_startup_show_full() -> bool {
-    true
-}
-
-fn default_plugged_in_startup_show_threshold() -> bool {
-    false
-}
-
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[serde(default)]
 pub struct PluggedInStartupNotification {
-    #[serde(default = "default_plugged_in_startup_show_full")]
     pub show_full: bool,
-
-    #[serde(default = "default_plugged_in_startup_show_threshold")]
     pub show_threshold: bool,
 }
 
 impl Default for PluggedInStartupNotification {
     fn default() -> Self {
         Self {
-            show_full: default_plugged_in_startup_show_full(),
-            show_threshold: default_plugged_in_startup_show_threshold(),
+            show_full: true,
+            show_threshold: false,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 
-use crate::notification::{BatteryFullNotification, ChargingHook, Notification, Urgency};
+use crate::notification::{
+    BatteryFullNotification, ChargingHookBase, ChargingStartHook, ChargingStopHook, Notification,
+    Urgency,
+};
 
 pub const CRITICAL_WAIT_TIME_SECS: u32 = 10000;
 pub const DEFAULT_POLL_INTERVAL_SECS: u32 = 60;
@@ -51,12 +54,12 @@ pub struct Config {
     // Optional hook fired when the AC adapter is plugged in
     // (Discharging -> Charging or Discharging -> Full).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub charging_start: Option<ChargingHook>,
+    pub charging_start: Option<ChargingStartHook>,
 
     // Optional hook fired when the AC adapter is unplugged
     // (Charging/Full -> Discharging).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub charging_stop: Option<ChargingHook>,
+    pub charging_stop: Option<ChargingStopHook>,
 
     // How often the poll loop reads the battery (seconds). Also bounds how
     // quickly plug/unplug hooks fire when UPower is unavailable.
@@ -254,24 +257,27 @@ pub fn get_default_config() -> Config {
         message: Some("Fully Charged 100%".to_string()),
     };
 
-    let charging_start = ChargingHook {
-        urgency: Urgency::Low,
-        enabled: false,
-        time_secs: None,
-        command: None,
-        title: Some("Charging".to_string()),
-        message: Some("Plugged in at {}%".to_string()),
-        show_threshold_warning: false,
+    let charging_start = ChargingStartHook {
+        base: ChargingHookBase {
+            urgency: Urgency::Low,
+            enabled: false,
+            time_secs: None,
+            command: None,
+            title: Some("Charging".to_string()),
+            message: Some("Plugged in at {}%".to_string()),
+        },
     };
 
-    let charging_stop = ChargingHook {
-        urgency: Urgency::Low,
-        enabled: false,
-        time_secs: None,
-        command: None,
-        title: Some("Discharging".to_string()),
-        message: Some("Unplugged at {}%".to_string()),
-        show_threshold_warning: true,
+    let charging_stop = ChargingStopHook {
+        base: ChargingHookBase {
+            urgency: Urgency::Low,
+            enabled: false,
+            time_secs: None,
+            command: None,
+            title: Some("Discharging".to_string()),
+            message: Some("Unplugged at {}%".to_string()),
+        },
+        show_threshold_warning_on_unplug: true,
     };
 
     Config {
@@ -417,10 +423,9 @@ mod tests {
         let cfg = get_default_config();
         let start = cfg.charging_start.expect("charging_start present");
         let stop = cfg.charging_stop.expect("charging_stop present");
-        assert!(!start.enabled);
-        assert!(!stop.enabled);
-        assert!(!start.show_threshold_warning);
-        assert!(stop.show_threshold_warning);
+        assert!(!start.base.enabled);
+        assert!(!stop.base.enabled);
+        assert!(stop.show_threshold_warning_on_unplug);
     }
 
     #[test]
@@ -437,14 +442,12 @@ mod tests {
     }
 
     #[test]
-    fn get_default_config_serde_roundtrip_preserves_show_threshold_warning() {
+    fn get_default_config_serde_roundtrip_preserves_show_threshold_warning_on_unplug() {
         let cfg = get_default_config();
         let s = serde_json::to_string(&cfg).expect("serialize default config");
         let back: Config = serde_json::from_str(&s).expect("deserialize default config");
-        let start = back.charging_start.expect("charging_start present");
         let stop = back.charging_stop.expect("charging_stop present");
-        assert!(!start.show_threshold_warning);
-        assert!(stop.show_threshold_warning);
+        assert!(stop.show_threshold_warning_on_unplug);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,10 +14,39 @@ fn default_poll_interval_secs() -> u32 {
     DEFAULT_POLL_INTERVAL_SECS
 }
 
+fn default_plugged_in_startup_show_full() -> bool {
+    true
+}
+
+fn default_plugged_in_startup_show_threshold() -> bool {
+    false
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub struct PluggedInStartupNotification {
+    #[serde(default = "default_plugged_in_startup_show_full")]
+    pub show_full: bool,
+
+    #[serde(default = "default_plugged_in_startup_show_threshold")]
+    pub show_threshold: bool,
+}
+
+impl Default for PluggedInStartupNotification {
+    fn default() -> Self {
+        Self {
+            show_full: default_plugged_in_startup_show_full(),
+            show_threshold: default_plugged_in_startup_show_threshold(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Config {
     pub notifications: Vec<Notification>,
     pub full_notification: BatteryFullNotification,
+
+    #[serde(default)]
+    pub plugged_in_startup_notification: PluggedInStartupNotification,
 
     // Optional hook fired when the AC adapter is plugged in
     // (Discharging -> Charging or Discharging -> Full).
@@ -232,6 +261,7 @@ pub fn get_default_config() -> Config {
         command: None,
         title: Some("Charging".to_string()),
         message: Some("Plugged in at {}%".to_string()),
+        show_threshold_warning: false,
     };
 
     let charging_stop = ChargingHook {
@@ -241,11 +271,13 @@ pub fn get_default_config() -> Config {
         command: None,
         title: Some("Discharging".to_string()),
         message: Some("Unplugged at {}%".to_string()),
+        show_threshold_warning: true,
     };
 
     Config {
         notifications,
         full_notification,
+        plugged_in_startup_notification: PluggedInStartupNotification::default(),
         charging_start: Some(charging_start),
         charging_stop: Some(charging_stop),
         poll_interval_secs: DEFAULT_POLL_INTERVAL_SECS,
@@ -296,6 +328,21 @@ mod tests {
         assert_eq!(cfg.poll_interval_secs, DEFAULT_POLL_INTERVAL_SECS);
         assert!(cfg.charging_start.is_none());
         assert!(cfg.charging_stop.is_none());
+        assert!(cfg.plugged_in_startup_notification.show_full);
+        assert!(!cfg.plugged_in_startup_notification.show_threshold);
+    }
+
+    #[test]
+    fn load_config_from_file_partial_plugged_in_startup_applies_defaults() {
+        let json = r#"{
+          "notifications": [],
+          "full_notification": {"urgency": "Low", "enabled": false},
+          "plugged_in_startup_notification": {"show_threshold": true}
+        }"#;
+        let f = write_tmp(json);
+        let cfg = load_config_from_file(&f.path().to_path_buf()).expect("load ok");
+        assert!(cfg.plugged_in_startup_notification.show_full);
+        assert!(cfg.plugged_in_startup_notification.show_threshold);
     }
 
     #[test]
@@ -372,12 +419,32 @@ mod tests {
         let stop = cfg.charging_stop.expect("charging_stop present");
         assert!(!start.enabled);
         assert!(!stop.enabled);
+        assert!(!start.show_threshold_warning);
+        assert!(stop.show_threshold_warning);
     }
 
     #[test]
     fn get_default_config_poll_interval_is_60() {
         let cfg = get_default_config();
         assert_eq!(cfg.poll_interval_secs, 60);
+    }
+
+    #[test]
+    fn get_default_config_plugged_in_startup_notification_defaults() {
+        let cfg = get_default_config();
+        assert!(cfg.plugged_in_startup_notification.show_full);
+        assert!(!cfg.plugged_in_startup_notification.show_threshold);
+    }
+
+    #[test]
+    fn get_default_config_serde_roundtrip_preserves_show_threshold_warning() {
+        let cfg = get_default_config();
+        let s = serde_json::to_string(&cfg).expect("serialize default config");
+        let back: Config = serde_json::from_str(&s).expect("deserialize default config");
+        let start = back.charging_start.expect("charging_start present");
+        let stop = back.charging_stop.expect("charging_stop present");
+        assert!(!start.show_threshold_warning);
+        assert!(stop.show_threshold_warning);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod notification;
 pub mod upower;
 
+use config::PluggedInStartupNotification;
 use notification::{BatteryFullNotification, ChargingHook, Urgency};
 use std::fs::File;
 use std::io::prelude::*;
@@ -245,6 +246,58 @@ pub fn reset_other_notifications(
     }
 }
 
+pub fn should_notify_threshold_on_startup(
+    charging_status: ChargingStatus,
+    config: PluggedInStartupNotification,
+) -> bool {
+    !charging_status.is_plugged_in() || config.show_threshold
+}
+
+pub fn should_notify_full_on_startup(
+    current: u32,
+    charging_status: ChargingStatus,
+    config: PluggedInStartupNotification,
+) -> bool {
+    current >= 100 && charging_status.is_plugged_in() && config.show_full
+}
+
+pub fn should_notify_threshold_on_unplug(
+    previous: ChargingStatus,
+    current: ChargingStatus,
+    show_threshold_warning: bool,
+) -> bool {
+    show_threshold_warning
+        && previous.is_plugged_in()
+        && matches!(current, ChargingStatus::Discharging)
+}
+
+pub fn send_full_battery_notification(full_notification: &mut BatteryFullNotification) {
+    if full_notification.notified || !full_notification.enabled {
+        return;
+    }
+
+    let title = full_notification
+        .title
+        .clone()
+        .unwrap_or("Battery Status".to_string());
+    let message = full_notification
+        .message
+        .clone()
+        .unwrap_or("Fully Charged 100%".to_string());
+    if let Err(err) = send_message(
+        &title,
+        &message,
+        &full_notification.urgency,
+        full_notification.time_secs,
+    ) {
+        warn_notification_failure(&err);
+    }
+    if let Some(cmd) = &full_notification.command {
+        run_command(cmd);
+    }
+    full_notification.notified = true;
+}
+
 /// notify if battery is fully charged
 pub fn check_notify_full_battery(
     current: &u32,
@@ -263,28 +316,15 @@ pub fn check_notify_full_battery(
         return;
     }
 
-    let title = full_notification
-        .title
-        .clone()
-        .unwrap_or("Battery Status".to_string());
-    let message = full_notification
-        .message
-        .clone()
-        .unwrap_or("Fully Charged 100%".to_string());
     if *current >= 100 {
-        if let Err(err) = send_message(&title, &message, &full_notification.urgency, None) {
-            warn_notification_failure(&err);
-        }
-        if let Some(cmd) = &full_notification.command {
-            run_command(cmd);
-        }
-        full_notification.notified = true;
+        send_full_battery_notification(full_notification);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::PluggedInStartupNotification;
     use crate::notification::{BatteryFullNotification, Notification, Urgency};
 
     // ---- ChargingStatus enum --------------------------------------------
@@ -560,6 +600,119 @@ mod tests {
         let mut map: HashMap<u32, Notification> = HashMap::new();
         reset_other_notifications(&10, &mut map);
         assert!(map.is_empty());
+    }
+
+    // ---- startup notification gating ------------------------------------
+
+    fn plugged_startup(show_full: bool, show_threshold: bool) -> PluggedInStartupNotification {
+        PluggedInStartupNotification {
+            show_full,
+            show_threshold,
+        }
+    }
+
+    #[test]
+    fn startup_threshold_disallowed_when_plugged_in_by_default() {
+        assert!(!should_notify_threshold_on_startup(
+            ChargingStatus::Charging,
+            PluggedInStartupNotification::default()
+        ));
+        assert!(!should_notify_threshold_on_startup(
+            ChargingStatus::Full,
+            PluggedInStartupNotification::default()
+        ));
+    }
+
+    #[test]
+    fn startup_threshold_allowed_when_discharging() {
+        assert!(should_notify_threshold_on_startup(
+            ChargingStatus::Discharging,
+            PluggedInStartupNotification::default()
+        ));
+    }
+
+    #[test]
+    fn startup_threshold_can_be_enabled_when_plugged_in() {
+        assert!(should_notify_threshold_on_startup(
+            ChargingStatus::Charging,
+            plugged_startup(true, true)
+        ));
+    }
+
+    #[test]
+    fn startup_full_allowed_when_plugged_in_and_full_by_default() {
+        assert!(should_notify_full_on_startup(
+            100,
+            ChargingStatus::Full,
+            PluggedInStartupNotification::default()
+        ));
+    }
+
+    #[test]
+    fn startup_full_can_be_disabled_when_plugged_in() {
+        assert!(!should_notify_full_on_startup(
+            100,
+            ChargingStatus::Full,
+            plugged_startup(false, false)
+        ));
+    }
+
+    #[test]
+    fn startup_full_requires_full_level_and_plugged_in_state() {
+        assert!(!should_notify_full_on_startup(
+            99,
+            ChargingStatus::Full,
+            PluggedInStartupNotification::default()
+        ));
+        assert!(!should_notify_full_on_startup(
+            100,
+            ChargingStatus::Discharging,
+            PluggedInStartupNotification::default()
+        ));
+    }
+
+    // ---- unplug notification gating -------------------------------------
+
+    #[test]
+    fn unplug_threshold_warning_enabled_for_plugged_to_discharging() {
+        assert!(should_notify_threshold_on_unplug(
+            ChargingStatus::Charging,
+            ChargingStatus::Discharging,
+            true
+        ));
+        assert!(should_notify_threshold_on_unplug(
+            ChargingStatus::Full,
+            ChargingStatus::Discharging,
+            true
+        ));
+    }
+
+    #[test]
+    fn unplug_threshold_warning_can_be_disabled() {
+        assert!(!should_notify_threshold_on_unplug(
+            ChargingStatus::Charging,
+            ChargingStatus::Discharging,
+            false
+        ));
+    }
+
+    #[test]
+    fn unplug_threshold_warning_requires_real_unplug_transition() {
+        assert!(!should_notify_threshold_on_unplug(
+            ChargingStatus::Charging,
+            ChargingStatus::Full,
+            true
+        ));
+        assert!(!should_notify_threshold_on_unplug(
+            ChargingStatus::Discharging,
+            ChargingStatus::Discharging,
+            true
+        ));
+        assert!(!should_notify_threshold_on_unplug(
+            ChargingStatus::Charging,
+            ChargingStatus::Unknown,
+            true
+        ));
     }
 
     // ---- check_notify_full_battery (no-side-effect branches only) ------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ pub mod notification;
 pub mod upower;
 
 use config::PluggedInStartupNotification;
-use notification::{BatteryFullNotification, ChargingHook, Urgency};
+use notification::{BatteryFullNotification, ChargingHookBase, Urgency};
 use std::fs::File;
 use std::io::prelude::*;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -188,7 +188,7 @@ pub fn send_notification(level: &u32, notification: &notification::Notification)
 }
 
 // hook to fire notification / run command on plugin/plugout
-pub fn fire_plugin_plugout_hook(level: u32, hook: &ChargingHook) {
+pub fn fire_plugin_plugout_hook(level: u32, hook: &ChargingHookBase) {
     if !hook.enabled {
         return;
     }
@@ -601,8 +601,6 @@ mod tests {
         reset_other_notifications(&10, &mut map);
         assert!(map.is_empty());
     }
-
-    // ---- startup notification gating ------------------------------------
 
     fn plugged_startup(show_full: bool, show_threshold: bool) -> PluggedInStartupNotification {
         PluggedInStartupNotification {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,14 +9,14 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::{thread, time};
 
-use powernotd::notification::{ChargingHook, Notification};
+use powernotd::notification::{ChargingStartHook, ChargingStopHook, Notification};
 
 fn plugin_plugout_check_fallback(
     battery: Option<&Battery>,
     level: u32,
     last_charging_status: &mut Option<ChargingStatus>,
-    charging_start: &Option<Arc<ChargingHook>>,
-    charging_stop: &Option<Arc<ChargingHook>>,
+    charging_start: &Option<Arc<ChargingStartHook>>,
+    charging_stop: &Option<Arc<ChargingStopHook>>,
 ) {
     let current = get_charging_status(battery);
     if matches!(current, ChargingStatus::Unknown) {
@@ -29,12 +29,12 @@ fn plugin_plugout_check_fallback(
             && is_plugged
             && let Some(hook) = charging_start
         {
-            fire_plugin_plugout_hook(level, hook);
+            fire_plugin_plugout_hook(level, &hook.base);
         } else if was_plugged
             && !is_plugged
             && let Some(hook) = charging_stop
         {
-            fire_plugin_plugout_hook(level, hook);
+            fire_plugin_plugout_hook(level, &hook.base);
         }
     }
     *last_charging_status = Some(current);
@@ -47,9 +47,9 @@ fn main() {
 
     let battery: Option<&Battery> = args.battery.as_deref();
 
-    // these paths are required for reading power supply status; skip the
-    // check for flags that don't touch battery state.
-    if !args.list_thresholds && !args.show_config_path && !args.emit_default_config {
+    let needs_battery_state =
+        !args.list_thresholds && !args.show_config_path && !args.emit_default_config;
+    if needs_battery_state {
         let required_paths = vec![
             PathBuf::from(get_power_status_path(battery)),
             PathBuf::from(get_charging_status_path(battery)),
@@ -136,7 +136,7 @@ fn main() {
     let charging_stop_arc = config.charging_stop.take().map(Arc::new);
     let show_threshold_warning_on_unplug = charging_stop_arc
         .as_ref()
-        .map(|hook| hook.show_threshold_warning)
+        .map(|hook| hook.show_threshold_warning_on_unplug)
         .unwrap_or(true);
 
     // Prefer event-driven plug/unplug detection via UPower. If unavailable

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ fn main() {
 
     // these paths are required for reading power supply status; skip the
     // check for flags that don't touch battery state.
-    if !args.list_thresholds && !args.show_config_path {
+    if !args.list_thresholds && !args.show_config_path && !args.emit_default_config {
         let required_paths = vec![
             PathBuf::from(get_power_status_path(battery)),
             PathBuf::from(get_charging_status_path(battery)),
@@ -63,6 +63,17 @@ fn main() {
                 std::process::exit(1);
             }
         }
+    }
+
+    if args.emit_default_config {
+        match serde_json::to_string_pretty(&config::get_default_config()) {
+            Ok(json) => println!("{}", json),
+            Err(err) => {
+                eprintln!("Could not serialize default config: {}", err);
+                std::process::exit(1);
+            }
+        }
+        return;
     }
 
     if args.status_level {
@@ -117,9 +128,16 @@ fn main() {
     let sleep_time = time::Duration::from_secs(config.poll_interval_secs.max(1) as u64);
     let mut last_battery_level: u32 = 100;
     let mut last_charging_status: Option<ChargingStatus> = None;
+    let startup_charging_status = get_charging_status(battery);
+    let mut last_threshold_charging_status = startup_charging_status;
+    let mut is_first_tick = true;
 
     let charging_start_arc = config.charging_start.take().map(Arc::new);
     let charging_stop_arc = config.charging_stop.take().map(Arc::new);
+    let show_threshold_warning_on_unplug = charging_stop_arc
+        .as_ref()
+        .map(|hook| hook.show_threshold_warning)
+        .unwrap_or(true);
 
     // Prefer event-driven plug/unplug detection via UPower. If unavailable
     // (no D-Bus, UPower not running, or device path not found), fall back to
@@ -147,11 +165,23 @@ fn main() {
 
     loop {
         let level = get_current_power(battery);
+        let current_charging_status = get_charging_status(battery);
         let current_threshold = find_lowest_threshold(level, &notified);
+        let allow_threshold_notification = !is_first_tick
+            || should_notify_threshold_on_startup(
+                startup_charging_status,
+                config.plugged_in_startup_notification,
+            );
+        let allow_unplug_threshold_warning = should_notify_threshold_on_unplug(
+            last_threshold_charging_status,
+            current_charging_status,
+            show_threshold_warning_on_unplug,
+        );
         if let Some(threshold_val) = current_threshold {
             if let Some(notification) = notified.get_mut(&threshold_val)
                 && !notification.notified
-                && level < last_battery_level
+                && ((level < last_battery_level && allow_threshold_notification)
+                    || allow_unplug_threshold_warning)
             {
                 send_notification(&level, notification);
                 notification.notified = true;
@@ -159,9 +189,21 @@ fn main() {
             reset_other_notifications(&threshold_val, &mut notified);
         }
 
-        check_notify_full_battery(&level, &last_battery_level, &mut config.full_notification);
+        if is_first_tick
+            && should_notify_full_on_startup(
+                level,
+                startup_charging_status,
+                config.plugged_in_startup_notification,
+            )
+        {
+            send_full_battery_notification(&mut config.full_notification);
+        } else {
+            check_notify_full_battery(&level, &last_battery_level, &mut config.full_notification);
+        }
 
         last_battery_level = level;
+        last_threshold_charging_status = current_charging_status;
+        is_first_tick = false;
 
         if !upower_active {
             plugin_plugout_check_fallback(

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,16 @@ use std::{thread, time};
 
 use powernotd::notification::{ChargingStartHook, ChargingStopHook, Notification};
 
+fn emit_default_config() {
+    match serde_json::to_string_pretty(&config::get_default_config()) {
+        Ok(json) => println!("{}", json),
+        Err(err) => {
+            eprintln!("Could not serialize default config: {}", err);
+            std::process::exit(1);
+        }
+    }
+}
+
 fn plugin_plugout_check_fallback(
     battery: Option<&Battery>,
     level: u32,
@@ -66,13 +76,7 @@ fn main() {
     }
 
     if args.emit_default_config {
-        match serde_json::to_string_pretty(&config::get_default_config()) {
-            Ok(json) => println!("{}", json),
-            Err(err) => {
-                eprintln!("Could not serialize default config: {}", err);
-                std::process::exit(1);
-            }
-        }
+        emit_default_config();
         return;
     }
 

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,6 +1,10 @@
 use notify_rust::Urgency as SendUrgency;
 use serde::{Deserialize, Serialize};
 
+fn default_show_threshold_warning() -> bool {
+    true
+}
+
 #[derive(Eq, PartialEq, Hash, Copy, Clone, Debug, Deserialize, Serialize)]
 pub enum Urgency {
     /// The behaviour for `Low` urgency depends on the notification server.
@@ -73,6 +77,16 @@ pub struct ChargingHook {
     // optional notification message; '{}' is replaced with the current battery level.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+
+    // Only consulted on the `charging_stop` hook (i.e. when the AC adapter is
+    // unplugged): show the matching threshold warning on unplug if the current
+    // battery level is already below a configured threshold. On `charging_start`
+    // this field is parsed but ignored — by the time plug-in fires, any
+    // relevant threshold warning has already either fired during the preceding
+    // discharge or did not apply. Kept on the shared `ChargingHook` type so the
+    // config format stays uniform.
+    #[serde(default = "default_show_threshold_warning")]
+    pub show_threshold_warning: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -249,6 +263,7 @@ mod tests {
             command: Some("xset dpms force on".to_string()),
             title: Some("Charging".to_string()),
             message: Some("Plugged in at {}%".to_string()),
+            show_threshold_warning: true,
         };
         let s = serde_json::to_string(&h).unwrap();
         let back: ChargingHook = serde_json::from_str(&s).unwrap();
@@ -258,6 +273,7 @@ mod tests {
         assert_eq!(back.command.as_deref(), Some("xset dpms force on"));
         assert_eq!(back.title.as_deref(), Some("Charging"));
         assert_eq!(back.message.as_deref(), Some("Plugged in at {}%"));
+        assert!(back.show_threshold_warning);
     }
 
     #[test]
@@ -270,6 +286,7 @@ mod tests {
         assert!(back.command.is_none());
         assert!(back.title.is_none());
         assert!(back.message.is_none());
+        assert!(back.show_threshold_warning);
     }
 
     #[test]
@@ -281,12 +298,51 @@ mod tests {
             command: None,
             title: None,
             message: None,
+            show_threshold_warning: false,
         };
         let s = serde_json::to_string(&h).unwrap();
         assert!(!s.contains("command"), "got: {s}");
         assert!(!s.contains("title"), "got: {s}");
         assert!(!s.contains("message"), "got: {s}");
         assert!(!s.contains("time_secs"), "got: {s}");
+    }
+
+    #[test]
+    fn charging_hook_show_threshold_warning_false_survives_roundtrip() {
+        let h = ChargingHook {
+            urgency: Urgency::Low,
+            enabled: false,
+            time_secs: None,
+            command: None,
+            title: None,
+            message: None,
+            show_threshold_warning: false,
+        };
+        let s = serde_json::to_string(&h).unwrap();
+        let back: ChargingHook = serde_json::from_str(&s).unwrap();
+        assert!(!back.show_threshold_warning);
+    }
+
+    #[test]
+    fn charging_hook_show_threshold_warning_always_serialized() {
+        let h = ChargingHook {
+            urgency: Urgency::Low,
+            enabled: false,
+            time_secs: None,
+            command: None,
+            title: None,
+            message: None,
+            show_threshold_warning: false,
+        };
+        let s = serde_json::to_string(&h).unwrap();
+        assert!(s.contains("\"show_threshold_warning\":false"), "got: {s}");
+    }
+
+    #[test]
+    fn charging_hook_minimal_json_defaults_show_threshold_warning_to_true() {
+        let json = r#"{"urgency":"Low","enabled":false}"#;
+        let back: ChargingHook = serde_json::from_str(json).unwrap();
+        assert!(back.show_threshold_warning);
     }
 
     // ---- BatteryFullNotification serde ----------------------------------

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -56,7 +56,7 @@ pub struct Notification {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ChargingHook {
+pub struct ChargingHookBase {
     pub urgency: Urgency,
     // if disabled the hook does not fire
     pub enabled: bool,
@@ -77,16 +77,26 @@ pub struct ChargingHook {
     // optional notification message; '{}' is replaced with the current battery level.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+}
 
-    // Only consulted on the `charging_stop` hook (i.e. when the AC adapter is
-    // unplugged): show the matching threshold warning on unplug if the current
-    // battery level is already below a configured threshold. On `charging_start`
-    // this field is parsed but ignored — by the time plug-in fires, any
-    // relevant threshold warning has already either fired during the preceding
-    // discharge or did not apply. Kept on the shared `ChargingHook` type so the
-    // config format stays uniform.
-    #[serde(default = "default_show_threshold_warning")]
-    pub show_threshold_warning: bool,
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ChargingStartHook {
+    #[serde(flatten)]
+    pub base: ChargingHookBase,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ChargingStopHook {
+    #[serde(flatten)]
+    pub base: ChargingHookBase,
+
+    // Show the matching threshold warning on unplug if the current battery
+    // level is already below a configured threshold.
+    #[serde(
+        default = "default_show_threshold_warning",
+        alias = "show_threshold_warning"
+    )]
+    pub show_threshold_warning_on_unplug: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -252,53 +262,69 @@ mod tests {
         assert!(!back.notified);
     }
 
-    // ---- ChargingHook serde ---------------------------------------------
+    // ---- ChargingStartHook serde ----------------------------------------
 
     #[test]
-    fn charging_hook_roundtrip_full() {
-        let h = ChargingHook {
-            urgency: Urgency::Normal,
-            enabled: true,
-            time_secs: Some(5),
-            command: Some("xset dpms force on".to_string()),
-            title: Some("Charging".to_string()),
-            message: Some("Plugged in at {}%".to_string()),
-            show_threshold_warning: true,
+    fn charging_start_hook_roundtrip_full() {
+        let h = ChargingStartHook {
+            base: ChargingHookBase {
+                urgency: Urgency::Normal,
+                enabled: true,
+                time_secs: Some(5),
+                command: Some("xset dpms force on".to_string()),
+                title: Some("Charging".to_string()),
+                message: Some("Plugged in at {}%".to_string()),
+            },
         };
         let s = serde_json::to_string(&h).unwrap();
-        let back: ChargingHook = serde_json::from_str(&s).unwrap();
-        assert_eq!(back.urgency, Urgency::Normal);
-        assert!(back.enabled);
-        assert_eq!(back.time_secs, Some(5));
-        assert_eq!(back.command.as_deref(), Some("xset dpms force on"));
-        assert_eq!(back.title.as_deref(), Some("Charging"));
-        assert_eq!(back.message.as_deref(), Some("Plugged in at {}%"));
-        assert!(back.show_threshold_warning);
+        let back: ChargingStartHook = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.base.urgency, Urgency::Normal);
+        assert!(back.base.enabled);
+        assert_eq!(back.base.time_secs, Some(5));
+        assert_eq!(back.base.command.as_deref(), Some("xset dpms force on"));
+        assert_eq!(back.base.title.as_deref(), Some("Charging"));
+        assert_eq!(back.base.message.as_deref(), Some("Plugged in at {}%"));
     }
 
     #[test]
-    fn charging_hook_roundtrip_minimal() {
+    fn charging_start_hook_roundtrip_minimal() {
         let json = r#"{"urgency":"Low","enabled":false}"#;
-        let back: ChargingHook = serde_json::from_str(json).unwrap();
-        assert_eq!(back.urgency, Urgency::Low);
-        assert!(!back.enabled);
-        assert!(back.time_secs.is_none());
-        assert!(back.command.is_none());
-        assert!(back.title.is_none());
-        assert!(back.message.is_none());
-        assert!(back.show_threshold_warning);
+        let back: ChargingStartHook = serde_json::from_str(json).unwrap();
+        assert_eq!(back.base.urgency, Urgency::Low);
+        assert!(!back.base.enabled);
+        assert!(back.base.time_secs.is_none());
+        assert!(back.base.command.is_none());
+        assert!(back.base.title.is_none());
+        assert!(back.base.message.is_none());
     }
 
     #[test]
-    fn charging_hook_skips_none_command_on_serialize() {
-        let h = ChargingHook {
-            urgency: Urgency::Low,
-            enabled: false,
-            time_secs: None,
-            command: None,
-            title: None,
-            message: None,
-            show_threshold_warning: false,
+    fn charging_start_hook_does_not_serialize_show_threshold_warning() {
+        let h = ChargingStartHook {
+            base: ChargingHookBase {
+                urgency: Urgency::Low,
+                enabled: false,
+                time_secs: None,
+                command: None,
+                title: None,
+                message: None,
+            },
+        };
+        let s = serde_json::to_string(&h).unwrap();
+        assert!(!s.contains("show_threshold_warning"), "got: {s}");
+    }
+
+    #[test]
+    fn charging_start_hook_skips_none_fields_on_serialize() {
+        let h = ChargingStartHook {
+            base: ChargingHookBase {
+                urgency: Urgency::Low,
+                enabled: false,
+                time_secs: None,
+                command: None,
+                title: None,
+                message: None,
+            },
         };
         let s = serde_json::to_string(&h).unwrap();
         assert!(!s.contains("command"), "got: {s}");
@@ -307,42 +333,78 @@ mod tests {
         assert!(!s.contains("time_secs"), "got: {s}");
     }
 
+    // ---- ChargingStopHook serde -----------------------------------------
+
     #[test]
-    fn charging_hook_show_threshold_warning_false_survives_roundtrip() {
-        let h = ChargingHook {
-            urgency: Urgency::Low,
-            enabled: false,
-            time_secs: None,
-            command: None,
-            title: None,
-            message: None,
-            show_threshold_warning: false,
+    fn charging_stop_hook_roundtrip_full() {
+        let h = ChargingStopHook {
+            base: ChargingHookBase {
+                urgency: Urgency::Normal,
+                enabled: true,
+                time_secs: Some(5),
+                command: Some("xset dpms force off".to_string()),
+                title: Some("Discharging".to_string()),
+                message: Some("Unplugged at {}%".to_string()),
+            },
+            show_threshold_warning_on_unplug: true,
         };
         let s = serde_json::to_string(&h).unwrap();
-        let back: ChargingHook = serde_json::from_str(&s).unwrap();
-        assert!(!back.show_threshold_warning);
+        let back: ChargingStopHook = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.base.urgency, Urgency::Normal);
+        assert!(back.base.enabled);
+        assert!(back.show_threshold_warning_on_unplug);
     }
 
     #[test]
-    fn charging_hook_show_threshold_warning_always_serialized() {
-        let h = ChargingHook {
-            urgency: Urgency::Low,
-            enabled: false,
-            time_secs: None,
-            command: None,
-            title: None,
-            message: None,
-            show_threshold_warning: false,
+    fn charging_stop_hook_show_threshold_warning_on_unplug_false_survives_roundtrip() {
+        let h = ChargingStopHook {
+            base: ChargingHookBase {
+                urgency: Urgency::Low,
+                enabled: false,
+                time_secs: None,
+                command: None,
+                title: None,
+                message: None,
+            },
+            show_threshold_warning_on_unplug: false,
         };
         let s = serde_json::to_string(&h).unwrap();
-        assert!(s.contains("\"show_threshold_warning\":false"), "got: {s}");
+        let back: ChargingStopHook = serde_json::from_str(&s).unwrap();
+        assert!(!back.show_threshold_warning_on_unplug);
     }
 
     #[test]
-    fn charging_hook_minimal_json_defaults_show_threshold_warning_to_true() {
+    fn charging_stop_hook_show_threshold_warning_on_unplug_always_serialized() {
+        let h = ChargingStopHook {
+            base: ChargingHookBase {
+                urgency: Urgency::Low,
+                enabled: false,
+                time_secs: None,
+                command: None,
+                title: None,
+                message: None,
+            },
+            show_threshold_warning_on_unplug: false,
+        };
+        let s = serde_json::to_string(&h).unwrap();
+        assert!(
+            s.contains("\"show_threshold_warning_on_unplug\":false"),
+            "got: {s}"
+        );
+    }
+
+    #[test]
+    fn charging_stop_hook_minimal_json_defaults_show_threshold_warning_on_unplug_to_true() {
         let json = r#"{"urgency":"Low","enabled":false}"#;
-        let back: ChargingHook = serde_json::from_str(json).unwrap();
-        assert!(back.show_threshold_warning);
+        let back: ChargingStopHook = serde_json::from_str(json).unwrap();
+        assert!(back.show_threshold_warning_on_unplug);
+    }
+
+    #[test]
+    fn charging_stop_hook_old_show_threshold_warning_key_still_parses() {
+        let json = r#"{"urgency":"Low","enabled":false,"show_threshold_warning":false}"#;
+        let back: ChargingStopHook = serde_json::from_str(json).unwrap();
+        assert!(!back.show_threshold_warning_on_unplug);
     }
 
     // ---- BatteryFullNotification serde ----------------------------------

--- a/src/upower.rs
+++ b/src/upower.rs
@@ -1,4 +1,4 @@
-use crate::notification::ChargingHook;
+use crate::notification::{ChargingStartHook, ChargingStopHook};
 use crate::{ChargingStatus, DEFAULT_BATTERY, fire_plugin_plugout_hook, get_current_power};
 use std::sync::Arc;
 use std::thread;
@@ -54,8 +54,8 @@ fn iface_name() -> InterfaceName<'static> {
 // -> on error we have a fallback at the caller
 pub fn try_spawn_listener(
     battery: Option<String>,
-    charging_start: Option<Arc<ChargingHook>>,
-    charging_stop: Option<Arc<ChargingHook>>,
+    charging_start: Option<Arc<ChargingStartHook>>,
+    charging_stop: Option<Arc<ChargingStopHook>>,
 ) -> zbus::Result<()> {
     let conn = Connection::system()?;
 
@@ -127,13 +127,13 @@ pub fn try_spawn_listener(
                 && let Some(hook) = &charging_start
             {
                 let level = get_current_power(bat);
-                fire_plugin_plugout_hook(level, hook);
+                fire_plugin_plugout_hook(level, &hook.base);
             } else if was_plugged
                 && !is_plugged
                 && let Some(hook) = &charging_stop
             {
                 let level = get_current_power(bat);
-                fire_plugin_plugout_hook(level, hook);
+                fire_plugin_plugout_hook(level, &hook.base);
             }
 
             last_status = current;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -83,6 +83,17 @@ fn show_config_path_prints_a_path() {
 }
 
 #[test]
+fn emit_default_config_prints_json_without_battery_files() {
+    powernotd()
+        .arg("--emit-default-config")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"notifications\""))
+        .stdout(predicate::str::contains("\"full_notification\""))
+        .stdout(predicate::str::contains("\"poll_interval_secs\": 60"));
+}
+
+#[test]
 fn unknown_flag_fails() {
     powernotd()
         .arg("--no-such-flag")


### PR DESCRIPTION
Ux issue fix:

 When starting up and it is already plugged in then I might not want to see in the first tick the threshold warning as I am already charging. Ignore this case (configurable) when starting up and it is plugged in.