### PR TITLE
Fix/notification daemon missing

### DIFF
--- a/pkg/assets/completions/_powernotd
+++ b/pkg/assets/completions/_powernotd
@@ -29,6 +29,7 @@ _powernotd() {
 '--list-thresholds[List all notification thresholds in the format '\''a_1%, a_2%, ..., a_n%'\'' that are specified in the config-file]' \
 '-p[Display the path to the config-file]' \
 '--show-config-path[Display the path to the config-file]' \
+'--mute-notification-warning[Suppress the stderr warning printed when no desktop notification daemon (dunst, mako, notification-daemon, xfce4-notifyd, ...) is reachable on D-Bus. Notifications still attempt to fire; this only silences the diagnostic]' \
 '-h[Print help]' \
 '--help[Print help]' \
 '-V[Print version]' \

--- a/pkg/assets/completions/_powernotd.ps1
+++ b/pkg/assets/completions/_powernotd.ps1
@@ -35,6 +35,7 @@ Register-ArgumentCompleter -Native -CommandName 'powernotd' -ScriptBlock {
             [CompletionResult]::new('--list-thresholds', '--list-thresholds', [CompletionResultType]::ParameterName, 'List all notification thresholds in the format ''a_1%, a_2%, ..., a_n%'' that are specified in the config-file')
             [CompletionResult]::new('-p', '-p', [CompletionResultType]::ParameterName, 'Display the path to the config-file')
             [CompletionResult]::new('--show-config-path', '--show-config-path', [CompletionResultType]::ParameterName, 'Display the path to the config-file')
+            [CompletionResult]::new('--mute-notification-warning', '--mute-notification-warning', [CompletionResultType]::ParameterName, 'Suppress the stderr warning printed when no desktop notification daemon (dunst, mako, notification-daemon, xfce4-notifyd, ...) is reachable on D-Bus. Notifications still attempt to fire; this only silences the diagnostic')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('-V', '-V ', [CompletionResultType]::ParameterName, 'Print version')

--- a/pkg/assets/completions/powernotd.bash
+++ b/pkg/assets/completions/powernotd.bash
@@ -23,7 +23,7 @@ _powernotd() {
 
     case "${cmd}" in
         powernotd)
-            opts="-s -c -f -n -t -p -b -h -V --status-level --charging-state --config-file --notify-now --list-thresholds --show-config-path --battery --help --version"
+            opts="-s -c -f -n -t -p -b -h -V --status-level --charging-state --config-file --notify-now --list-thresholds --show-config-path --battery --mute-notification-warning --help --version"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/pkg/assets/completions/powernotd.elv
+++ b/pkg/assets/completions/powernotd.elv
@@ -32,6 +32,7 @@ set edit:completion:arg-completer[powernotd] = {|@words|
             cand --list-thresholds 'List all notification thresholds in the format ''a_1%, a_2%, ..., a_n%'' that are specified in the config-file'
             cand -p 'Display the path to the config-file'
             cand --show-config-path 'Display the path to the config-file'
+            cand --mute-notification-warning 'Suppress the stderr warning printed when no desktop notification daemon (dunst, mako, notification-daemon, xfce4-notifyd, ...) is reachable on D-Bus. Notifications still attempt to fire; this only silences the diagnostic'
             cand -h 'Print help'
             cand --help 'Print help'
             cand -V 'Print version'

--- a/pkg/assets/completions/powernotd.fish
+++ b/pkg/assets/completions/powernotd.fish
@@ -5,5 +5,6 @@ complete -c powernotd -s c -l charging-state -d 'Print charging status \'chargin
 complete -c powernotd -s n -l notify-now -d 'Send desktop notification with current battery-level then exit'
 complete -c powernotd -s t -l list-thresholds -d 'List all notification thresholds in the format \'a_1%, a_2%, ..., a_n%\' that are specified in the config-file'
 complete -c powernotd -s p -l show-config-path -d 'Display the path to the config-file'
+complete -c powernotd -l mute-notification-warning -d 'Suppress the stderr warning printed when no desktop notification daemon (dunst, mako, notification-daemon, xfce4-notifyd, ...) is reachable on D-Bus. Notifications still attempt to fire; this only silences the diagnostic'
 complete -c powernotd -s h -l help -d 'Print help'
 complete -c powernotd -s V -l version -d 'Print version'

--- a/pkg/assets/man/powernotd.1
+++ b/pkg/assets/man/powernotd.1
@@ -1,10 +1,10 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH powernotd 1  "powernotd 1.3.0" 
+.TH powernotd 1  "powernotd 1.2.0" 
 .SH NAME
 powernotd \- Powernotd is a battery\-level notification daemon that sends notification using the xdg desktop notification standard.
 .SH SYNOPSIS
-\fBpowernotd\fR [\fB\-s\fR|\fB\-\-status\-level\fR] [\fB\-c\fR|\fB\-\-charging\-state\fR] [\fB\-f\fR|\fB\-\-config\-file\fR] [\fB\-n\fR|\fB\-\-notify\-now\fR] [\fB\-t\fR|\fB\-\-list\-thresholds\fR] [\fB\-p\fR|\fB\-\-show\-config\-path\fR] [\fB\-b\fR|\fB\-\-battery\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] 
+\fBpowernotd\fR [\fB\-s\fR|\fB\-\-status\-level\fR] [\fB\-c\fR|\fB\-\-charging\-state\fR] [\fB\-f\fR|\fB\-\-config\-file\fR] [\fB\-n\fR|\fB\-\-notify\-now\fR] [\fB\-t\fR|\fB\-\-list\-thresholds\fR] [\fB\-p\fR|\fB\-\-show\-config\-path\fR] [\fB\-b\fR|\fB\-\-battery\fR] [\fB\-\-mute\-notification\-warning\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] 
 .SH DESCRIPTION
 Powernotd is a battery\-level notification daemon that sends notification using the xdg desktop notification standard.
 .SH OPTIONS
@@ -30,12 +30,15 @@ Display the path to the config\-file
 \fB\-b\fR, \fB\-\-battery\fR \fI<BATTERY>\fR
 Pass the battery such as \*(AqBAT1\*(Aq if your system has multiple and you do not want to use the default (BAT0). Check \*(Aq/sys/class/power_supply/\*(Aq to see which batteries you have
 .TP
+\fB\-\-mute\-notification\-warning\fR
+Suppress the stderr warning printed when no desktop notification daemon (dunst, mako, notification\-daemon, xfce4\-notifyd, ...) is reachable on D\-Bus. Notifications still attempt to fire; this only silences the diagnostic
+.TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .TP
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v1.3.0
+v1.2.0
 .SH AUTHORS
 laeri@laeri.me

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,12 @@ pub struct Args {
     /// default (BAT0). Check '/sys/class/power_supply/' to see which batteries you have.
     #[arg(short = 'b', long)]
     pub battery: Option<String>,
+
+    /// Suppress the stderr warning printed when no desktop notification daemon
+    /// (dunst, mako, notification-daemon, xfce4-notifyd, ...) is reachable on D-Bus.
+    /// Notifications still attempt to fire; this only silences the diagnostic.
+    #[arg(long, default_value_t = false)]
+    pub mute_notification_warning: bool,
 }
 
 /// used within build.rs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,16 @@ pub mod upower;
 use notification::{BatteryFullNotification, ChargingHook, Urgency};
 use std::fs::File;
 use std::io::prelude::*;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{collections::HashMap, process::Command};
+
+static MUTE_NOTIFICATION_WARNING: AtomicBool = AtomicBool::new(false);
+
+/// Globally suppress the diagnostic emitted by `warn_notification_failure`.
+/// Intended to back the `--mute-notification-warning` CLI flag.
+pub fn set_mute_notification_warning(mute: bool) {
+    MUTE_NOTIFICATION_WARNING.store(mute, Ordering::Relaxed);
+}
 
 pub type Battery = str;
 
@@ -90,7 +99,12 @@ pub fn get_charging_status_text(battery: Option<&Battery>) -> String {
 }
 
 /// send a message using linux notify-send api
-pub fn send_message(title: &str, message: &str, urgency: &Urgency, time_secs: Option<u32>) {
+pub fn send_message(
+    title: &str,
+    message: &str,
+    urgency: &Urgency,
+    time_secs: Option<u32>,
+) -> notify_rust::error::Result<()> {
     let mut notification = notify_rust::Notification::new();
 
     notification
@@ -102,7 +116,21 @@ pub fn send_message(title: &str, message: &str, urgency: &Urgency, time_secs: Op
         notification.timeout(notify_rust::Timeout::Milliseconds(wait_time * 1000));
         //milliseconds
     }
-    notification.show().unwrap();
+    notification.show()?;
+    Ok(())
+}
+
+pub fn warn_notification_failure(err: &notify_rust::error::Error) {
+    if MUTE_NOTIFICATION_WARNING.load(Ordering::Relaxed) {
+        return;
+    }
+    eprintln!("Could not send desktop notification: {}", err);
+    eprintln!(
+        "Hint: powernotd needs a running notification daemon (e.g. dunst, mako, \
+         notification-daemon, xfce4-notifyd). Install and start one, or ensure it \
+         is launched before powernotd in your session/service ordering. \
+         Pass --mute-notification-warning to silence this message."
+    );
 }
 
 pub fn run_command(command: &str) {
@@ -145,12 +173,14 @@ pub fn send_notification(level: &u32, notification: &notification::Notification)
     let message = notification.message.clone().unwrap_or("{}".to_string());
     let percent = format!("{}", level);
 
-    send_message(
+    if let Err(err) = send_message(
         &title.replace("{}", &percent),
         &message.replace("{}", &percent),
         &notification.urgency,
         notification.time_secs,
-    );
+    ) {
+        warn_notification_failure(&err);
+    }
     if let Some(cmd) = &notification.command {
         run_command(cmd);
     }
@@ -168,12 +198,14 @@ pub fn fire_plugin_plugout_hook(level: u32, hook: &ChargingHook) {
             .unwrap_or_else(|| "Battery Status".to_string());
         let message = hook.message.clone().unwrap_or_else(|| "{}%".to_string());
         let percent = format!("{}", level);
-        send_message(
+        if let Err(err) = send_message(
             &title.replace("{}", &percent),
             &message.replace("{}", &percent),
             &hook.urgency,
             hook.time_secs,
-        );
+        ) {
+            warn_notification_failure(&err);
+        }
     }
     if let Some(cmd) = &hook.command {
         run_command(cmd);
@@ -183,7 +215,7 @@ pub fn fire_plugin_plugout_hook(level: u32, hook: &ChargingHook) {
 pub fn notify_now(level: &u32) {
     let percent = format!("{}%", level);
     let default_wait_time = 10; // seconds
-    send_message(
+    let _ = send_message(
         "Battery Status",
         &percent,
         &Urgency::Normal,
@@ -240,7 +272,9 @@ pub fn check_notify_full_battery(
         .clone()
         .unwrap_or("Fully Charged 100%".to_string());
     if *current >= 100 {
-        send_message(&title, &message, &full_notification.urgency, None);
+        if let Err(err) = send_message(&title, &message, &full_notification.urgency, None) {
+            warn_notification_failure(&err);
+        }
         if let Some(cmd) = &full_notification.command {
             run_command(cmd);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,8 @@ fn plugin_plugout_check_fallback(
 fn main() {
     let args = Args::parse();
 
+    set_mute_notification_warning(args.mute_notification_warning);
+
     let battery: Option<&Battery> = args.battery.as_deref();
 
     // these paths are required for reading power supply status; skip the


### PR DESCRIPTION
- when notification daemon is missing print an error message and allow muting the message in case the daemon is not ready yet